### PR TITLE
docs(README): API token is expected in the PHABRICATOR_TOKEN env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Commands:
 For `phable` to work, you need to define the following environment variables:
 
 - `PHABRICATOR_URL`: URL to your phabricator instance. Ex: `PHABRICATOR_URL=https://phabricator.wikimedia.org`
-- `PHABRICATOR_API_TOKEN`: Generate a token from ${PHABRICATOR_URL}/settings/user/${YOUR_USERNAME}/page/apitokens/
+- `PHABRICATOR_TOKEN`: Generate a token from ${PHABRICATOR_URL}/settings/user/${YOUR_USERNAME}/page/apitokens/
 - `PHABRICATOR_DEFAULT_PROJECT_PHID`: id for the Phabricator project to be used by default when creating tasks.
 
 Note: to get `PHABRICATOR_DEFAULT_PROJECT_PHID`, define the first 2 environment variables, and run the following command, where T123456 is a task id belonging to your project.


### PR DESCRIPTION
Corrected typo: PHABRICATOR_API_TOKEN -> PHABRICATOR_TOKEN to reflect actual implementation.