### PR TITLE
fix(find_tasks): changes to method signature are propagated to callers

### DIFF
--- a/phable/cli/report.py
+++ b/phable/cli/report.py
@@ -51,7 +51,7 @@ def report_done_tasks(
     column_destination_phid = client.find_column_in_project(
         target_project_phid, destination
     )
-    tasks = client.find_tasks_in_column(column_source_phid)
+    tasks = client.find_tasks(column_phids=[column_source_phid])
 
     enriched_tasks = []
     for task in tasks:

--- a/phable/phabricator.py
+++ b/phable/phabricator.py
@@ -163,9 +163,6 @@ class PhabricatorClient:
         parent = self.find_parent_task(subtask_id=task["id"])
         task["parent"] = parent
 
-    def find_tasks_in_column(self, column_phid: str) -> list[dict[str, Any]]:
-        return self.find_tasks(column_phid=column_phid)
-
     def find_tasks(
         self,
         column_phids: Optional[list[str]] = None,


### PR DESCRIPTION
`PhabricatorClient.find_tasks()` signature was changed to allow mutliple column PHIDs to be passes, but caller
(`PhabricatorClient.find_tasks_by_column()`) was not updated. Given the new signature of `find_tasks()`, `find_tasks_by_column()` can now be inlined and removed.