### PR TITLE
Display formats

### DIFF
--- a/phable/cli/list.py
+++ b/phable/cli/list.py
@@ -1,9 +1,11 @@
+from pickle import FALSE
+
 import click
 from typing import Optional
 
 from phable.phabricator import PhabricatorClient
 from phable.config import config
-from phable.display import display_tasks
+from phable.display import display_tasks, TaskFormat
 
 
 @click.command(name="list")
@@ -30,7 +32,7 @@ from phable.display import display_tasks
 @click.option(
     "--format",
     required=False,
-    type=click.Choice(("html", "plain", "json", "markdown")),
+    type=click.Choice(TaskFormat, case_sensitive=False),
     default="plain",
     help="The output format of the task list",
 )
@@ -42,7 +44,7 @@ def list_tasks(
     columns: list[str],
     owner: Optional[str] = None,
     milestone: bool = False,
-    format: str = "plain",
+    format: TaskFormat = TaskFormat.PLAIN,
 ):
     """Lists and filter tasks
 

--- a/phable/cli/list.py
+++ b/phable/cli/list.py
@@ -78,4 +78,4 @@ def list_tasks(
         column_phids=column_phids, owner_phid=owner_user, project_phid=project_phid
     )
     tasks = [client.enrich_task(task) for task in tasks]
-    display_tasks(tasks=tasks, format=format, separator="")
+    display_tasks(tasks=tasks, format=format)

--- a/phable/cli/report.py
+++ b/phable/cli/report.py
@@ -1,7 +1,7 @@
 import click
 from phable.config import config
 from phable.phabricator import PhabricatorClient
-from phable.display import display_tasks
+from phable.display import display_tasks, TaskFormat
 
 
 @click.command(name="report-done-tasks")
@@ -15,7 +15,7 @@ from phable.display import display_tasks
 )
 @click.option(
     "--format",
-    type=click.Choice(("plain", "json")),
+    type=click.Choice(TaskFormat, case_sensitive=False),
     default="plain",
     help="Output format",
 )

--- a/phable/cli/show.py
+++ b/phable/cli/show.py
@@ -1,13 +1,13 @@
 import click
 from phable.utils import Task
 from phable.phabricator import PhabricatorClient
-from phable.display import display_task
+from phable.display import display_task, TaskFormat
 
 
 @click.command(name="show")
 @click.option(
     "--format",
-    type=click.Choice(("plain", "json")),
+    type=click.Choice(TaskFormat, case_sensitive=False),
     default="plain",
     help="Output format",
 )

--- a/phable/display.py
+++ b/phable/display.py
@@ -11,6 +11,7 @@ class TaskFormat(StrEnum):
     JSON = auto()
     HTML = auto()
     MARKDOWN = auto()
+    WIKITEXT = auto()
 
 
 def display_tasks(
@@ -53,6 +54,16 @@ class MarkdownTaskPrinter(TaskPrinter):
 
     def print(self, task: dict) -> None:
         self._printer(f"* [{self.title(task)}]({task['url']})")
+
+    def print_list(self, tasks: list[dict]) -> None:
+        for task in tasks:
+            self.print(task)
+
+
+class WikitextTaskPrinter(TaskPrinter):
+
+    def print(self, task: dict) -> None:
+        self._printer(f"* [{task['url']} {self.title(task)}]")
 
     def print_list(self, tasks: list[dict]) -> None:
         for task in tasks:
@@ -111,5 +122,7 @@ def get_printer(format: TaskFormat) -> TaskPrinter:
         return HtmlTaskPrinter(print)
     elif format == TaskFormat.MARKDOWN:
         return MarkdownTaskPrinter(print)
+    elif format == TaskFormat.WIKITEXT:
+        return WikitextTaskPrinter(print)
     else:
         raise ValueError(f"Unknown format: {format}")

--- a/phable/display.py
+++ b/phable/display.py
@@ -6,6 +6,25 @@ from .utils import Task
 TaskFormat: TypeAlias = Literal["plain", "json", "html", "markdown"]
 
 
+def display_tasks(
+    tasks: list[dict],
+    format: TaskFormat,
+    separator: str = "=" * 50,
+):
+    if len(tasks) == 1:
+        return display_task(tasks[0], format=format)
+
+    if format == "json":
+        print(json.dumps(tasks, indent=2))
+    elif format == "markdown":
+        for task in tasks:
+            display_task(task, format=format, prefix="* ")
+    else:
+        for task in tasks:
+            display_task(task, format=format, prefix="<li>", end="")
+            print(separator)
+
+
 def display_task(task: dict, format: TaskFormat, prefix: str = "", end: str = "\n"):
     title = f"{Task.from_int(task['id'])} {task['fields']['name']} ({task['fields']['status']['name']})"
 
@@ -47,22 +66,3 @@ def display_task(task: dict, format: TaskFormat, prefix: str = "", end: str = "\
                 print(
                     f"{status} - {Task.from_int(subtask['id'])} - @{subtask['owner']:<10} - {subtask['fields']['name']}"
                 )
-
-
-def display_tasks(
-    tasks: list[dict],
-    format: TaskFormat,
-    separator: str = "=" * 50,
-):
-    if len(tasks) == 1:
-        return display_task(tasks[0], format=format)
-
-    if format == "json":
-        print(json.dumps(tasks, indent=2))
-    elif format == "markdown":
-        for task in tasks:
-            display_task(task, format=format, prefix="* ")
-    else:
-        for task in tasks:
-            display_task(task, format=format, prefix="<li>", end="")
-            print(separator)

--- a/phable/display.py
+++ b/phable/display.py
@@ -1,10 +1,16 @@
 import json
 from collections.abc import Callable
-from typing import Literal, TypeAlias, Optional
+from enum import StrEnum, auto
+from typing import Literal, TypeAlias
 
 from .utils import Task
 
-TaskFormat: TypeAlias = Literal["plain", "json", "html", "markdown"]
+
+class TaskFormat(StrEnum):
+    PLAIN = auto()
+    JSON = auto()
+    HTML = auto()
+    MARKDOWN = auto()
 
 
 def display_tasks(
@@ -97,13 +103,13 @@ class PlainTaskPrinter(TaskPrinter):
 
 
 def get_printer(format: TaskFormat) -> TaskPrinter:
-    if format == "plain":
+    if format == TaskFormat.PLAIN:
         return PlainTaskPrinter(print)
-    elif format == "json":
+    elif format == TaskFormat.JSON:
         return JsonTaskPrinter(print)
-    elif format == "html":
+    elif format == TaskFormat.HTML:
         return HtmlTaskPrinter(print)
-    elif format == "markdown":
+    elif format == TaskFormat.MARKDOWN:
         return MarkdownTaskPrinter(print)
     else:
         raise ValueError(f"Unknown format: {format}")


### PR DESCRIPTION
refactor(display): convert if / elif to polymorphism
    
 The various display format are now encoded as a class hierarchy. This makes it easier to add additional formats. It also removes a bunch of peripheral configuration (prefix, end, ...) that were format specific, but managed outside of the formaters.
