### PR TITLE
List without column raises exception

### DIFF
--- a/phable/cli/list.py
+++ b/phable/cli/list.py
@@ -81,7 +81,7 @@ def list_tasks(
             for column in columns
         ]
     else:
-        column_phids = None
+        column_phids = []
     tasks = client.find_tasks(
         column_phids=column_phids, owner_phid=owner_user, project_phid=project_phid
     )

--- a/phable/phabricator.py
+++ b/phable/phabricator.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Any, Optional, TypeVar
+from typing import Any, Optional, TypeVar, Sequence
 from importlib.metadata import version
 import requests
 
@@ -167,7 +167,7 @@ class PhabricatorClient:
 
     def find_tasks(
         self,
-        column_phids: Optional[list[str]] = None,
+        column_phids: Sequence[str],
         owner_phid: Optional[str] = None,
         project_phid: Optional[str] = None,
     ) -> list[dict[str, Any]]:


### PR DESCRIPTION
    fix(PhabricatorClient.find_tasks): don't crash on no columns
    
    As described in the linked issue #10, when find_tasks is passed
    `columns=None` it crashes as it can't iterate `None`.
    
    `find_tasks()` now marks the `columns_phids` argument as a
    non optional sequence. This documents that this argument is
    expected to not be modified and that `None` should not be passed.
    
    Caller is modified to follow this new behaviour.
    
    fixes: #10
