### PR TITLE
test: add integration tests for the list command

### DIFF
--- a/phable/tests/cli/conftest.py
+++ b/phable/tests/cli/conftest.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 import pytest
+import responses
 
 from phable.cache import cache
 from phable.phabricator import PhabricatorClient
@@ -9,6 +10,12 @@ from phable.phabricator import PhabricatorClient
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 BASE_URL = "http://example.net/"
 TOKEN = "test_token"
+
+
+def add_response(endpoint: str, fixture: str):
+    responses.add(
+        responses.POST, BASE_URL + "api/" + endpoint, json=load_fixture(fixture)
+    )
 
 
 def load_fixture(name: str) -> dict:

--- a/phable/tests/cli/fixtures/current_user.json
+++ b/phable/tests/cli/fixtures/current_user.json
@@ -1,0 +1,17 @@
+{
+  "result": {
+    "phid": "PHID-USER-oknilgmxl4rosyulvny7",
+    "userName": "Gehel",
+    "realName": "Guillaume Lederrey",
+    "image": "https://phab.wmfusercontent.org/file/data/wxni4dd2w73zpqvtmjdq/PHID-FILE-ywrfhopc4oo74akgzhxh/profile",
+    "uri": "https://phabricator.wikimedia.org/p/Gehel/",
+    "roles": [
+      "verified",
+      "approved",
+      "activated"
+    ],
+    "primaryEmail": "glederrey@wikimedia.org"
+  },
+  "error_code": null,
+  "error_info": null
+}

--- a/phable/tests/cli/fixtures/tasks_for_current_user.json
+++ b/phable/tests/cli/fixtures/tasks_for_current_user.json
@@ -1,0 +1,214 @@
+{
+  "result": {
+    "data": [
+      {
+        "id": 418664,
+        "type": "TASK",
+        "phid": "PHID-TASK-3czln7eispcasgrlyxlg",
+        "fields": {
+          "name": "Requesting Kerberos access for  SCardenas (WMF)",
+          "description": {
+            "raw": "* My username on wikitech.wikimedia.org is: SCardenas (WMF)\n* See https://wikitech.wikimedia.org/wiki/Analytics/Data_access\n\nI need access to `Analytics-privatedata-users` for my work as a software engineer in the Moderator Tools team."
+          },
+          "authorPHID": "PHID-USER-a3gzgfhvkpwcpjyibpik",
+          "ownerPHID": "PHID-USER-oknilgmxl4rosyulvny7",
+          "status": {
+            "value": "open",
+            "name": "Open",
+            "color": null
+          },
+          "priority": {
+            "value": 90,
+            "name": "Needs Triage",
+            "color": "violet"
+          },
+          "points": null,
+          "subtype": "default",
+          "closerPHID": null,
+          "dateClosed": null,
+          "groupByProjectPHID": null,
+          "spacePHID": "PHID-SPCE-6l6g5p53yi3mypnlpxjw",
+          "dateCreated": 1772244895,
+          "dateModified": 1774605157,
+          "policy": {
+            "view": "public",
+            "interact": "public",
+            "edit": "users"
+          },
+          "custom.deadline.due": null,
+          "custom.train.status": null,
+          "custom.train.backup": null,
+          "custom.external_reference": null,
+          "custom.release.version": null,
+          "custom.release.date": null,
+          "custom.security_topic": "default",
+          "custom.risk.summary": null,
+          "custom.risk.impacted": null,
+          "custom.risk.rating": null,
+          "custom.requestor.affiliation": null,
+          "custom.error.reqid": null,
+          "custom.error.stack": null,
+          "custom.error.url": null,
+          "custom.error.id": null,
+          "custom.points.final": null,
+          "custom.deadline.start": null
+        },
+        "attachments": {
+          "subscribers": {
+            "subscriberPHIDs": [
+              "PHID-USER-elsr3rwzokgy7mj2tras",
+              "PHID-USER-hgn5uw2jafgjgfvxibhh",
+              "PHID-USER-a3gzgfhvkpwcpjyibpik"
+            ],
+            "subscriberCount": 3,
+            "viewerIsSubscribed": true
+          },
+          "projects": {
+            "projectPHIDs": [
+              "PHID-PROJ-imzvjznpvtcs2rzya67g",
+              "PHID-PROJ-onnxucoedheq3jevknyr",
+              "PHID-PROJ-jlntasvg65b6mmtbpwwe",
+              "PHID-PROJ-gsfmtborh6beh6xj5lz6"
+            ]
+          },
+          "columns": {
+            "boards": {
+              "PHID-PROJ-imzvjznpvtcs2rzya67g": {
+                "columns": [
+                  {
+                    "id": 37254,
+                    "phid": "PHID-PCOL-ob5hy2de7kvwvmkdozhh",
+                    "name": "Blocked/Waiting"
+                  }
+                ]
+              },
+              "PHID-PROJ-gsfmtborh6beh6xj5lz6": {
+                "columns": [
+                  {
+                    "id": 20802,
+                    "phid": "PHID-PCOL-h4o5fuw27lpam6k7iu6p",
+                    "name": "Tag with Radar"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": 417573,
+        "type": "TASK",
+        "phid": "PHID-TASK-s5tgjk2nmq6kbwzkxybu",
+        "fields": {
+          "name": "Remove duplicate endpoints (Feb 16, 2026)",
+          "description": {
+            "raw": "The following endpoints on the Allowlist seem to be duplicates:\n\nhttps://beta.sparql.swisslipids.org/sparql shows up twice, one can be removed.\n\nAnd this one has two versions:\nhttp://dbpedia.org/sparql*\nhttp://dbpedia.org/sparql\n\nIs there a reason to have both versions on the list? From what I understand, * allows calling the endpoint with parameters.\n\n\n\n\n"
+          },
+          "authorPHID": "PHID-USER-fyy3girk4ijjrijyrmzj",
+          "ownerPHID": "PHID-USER-oknilgmxl4rosyulvny7",
+          "status": {
+            "value": "progress",
+            "name": "In Progress",
+            "color": "green"
+          },
+          "priority": {
+            "value": 25,
+            "name": "Low",
+            "color": "yellow"
+          },
+          "points": null,
+          "subtype": "default",
+          "closerPHID": null,
+          "dateClosed": null,
+          "groupByProjectPHID": null,
+          "spacePHID": "PHID-SPCE-6l6g5p53yi3mypnlpxjw",
+          "dateCreated": 1771239361,
+          "dateModified": 1774605133,
+          "policy": {
+            "view": "public",
+            "interact": "public",
+            "edit": "users"
+          },
+          "custom.deadline.due": null,
+          "custom.train.status": null,
+          "custom.train.backup": null,
+          "custom.external_reference": null,
+          "custom.release.version": null,
+          "custom.release.date": null,
+          "custom.security_topic": "default",
+          "custom.risk.summary": null,
+          "custom.risk.impacted": null,
+          "custom.risk.rating": null,
+          "custom.requestor.affiliation": null,
+          "custom.error.reqid": null,
+          "custom.error.stack": null,
+          "custom.error.url": null,
+          "custom.error.id": null,
+          "custom.points.final": null,
+          "custom.deadline.start": null
+        },
+        "attachments": {
+          "subscribers": {
+            "subscriberPHIDs": [
+              "PHID-USER-hgn5uw2jafgjgfvxibhh",
+              "PHID-USER-fyy3girk4ijjrijyrmzj"
+            ],
+            "subscriberCount": 2,
+            "viewerIsSubscribed": true
+          },
+          "projects": {
+            "projectPHIDs": [
+              "PHID-PROJ-imzvjznpvtcs2rzya67g",
+              "PHID-PROJ-onnxucoedheq3jevknyr",
+              "PHID-PROJ-ceqceb2bnio6alj5nxov",
+              "PHID-PROJ-7ocjej2gottz7cikkdc6"
+            ]
+          },
+          "columns": {
+            "boards": {
+              "PHID-PROJ-imzvjznpvtcs2rzya67g": {
+                "columns": [
+                  {
+                    "id": 37253,
+                    "phid": "PHID-PCOL-td2g73z3k4bbnsyepymv",
+                    "name": "Needs Review"
+                  }
+                ]
+              },
+              "PHID-PROJ-ceqceb2bnio6alj5nxov": {
+                "columns": [
+                  {
+                    "id": 3524,
+                    "phid": "PHID-PCOL-z32nynksl2xf566sviwb",
+                    "name": "Watching / Waiting"
+                  }
+                ]
+              },
+              "PHID-PROJ-7ocjej2gottz7cikkdc6": {
+                "columns": [
+                  {
+                    "id": 452,
+                    "phid": "PHID-PCOL-fsqe6373hzn3ml2iqpqq",
+                    "name": "incoming"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    ],
+    "maps": {},
+    "query": {
+      "queryKey": null
+    },
+    "cursor": {
+      "limit": 100,
+      "after": null,
+      "before": null,
+      "order": null
+    }
+  },
+  "error_code": null,
+  "error_info": null
+}

--- a/phable/tests/cli/fixtures/tasks_where_user_is_backup_owner.json
+++ b/phable/tests/cli/fixtures/tasks_where_user_is_backup_owner.json
@@ -1,0 +1,17 @@
+{
+  "result": {
+    "data": [],
+    "maps": {},
+    "query": {
+      "queryKey": null
+    },
+    "cursor": {
+      "limit": 100,
+      "after": null,
+      "before": null,
+      "order": null
+    }
+  },
+  "error_code": null,
+  "error_info": null
+}

--- a/phable/tests/cli/test_list.py
+++ b/phable/tests/cli/test_list.py
@@ -1,0 +1,53 @@
+import responses
+from click.testing import CliRunner
+
+from phable.cli.list import list_tasks
+from phable.phabricator import PhabricatorClient
+from phable.tests.cli.conftest import add_response
+
+
+def _add_find_tasks_mocks():
+    """One find_tasks call followed by per-task enrichment (author + projects)."""
+    add_response("maniphest.search", "show_task.json")
+    add_response("user.search", "show_user.json")
+    add_response("project.search", "show_projects.json")
+
+
+@responses.activate
+def test_list_tasks_oneline(client: PhabricatorClient):
+    _add_find_tasks_mocks()
+
+    result = CliRunner().invoke(list_tasks, ["--format", "oneline"], obj=client)
+
+    assert result.exit_code == 0, result.output
+    assert "T417698" in result.output
+    assert (
+        "Ensure select dse-k8s-hosted microservices can run active/active"
+        in result.output
+    )
+
+
+@responses.activate
+def test_list_tasks_with_owner_self(client: PhabricatorClient):
+    """--owner self triggers user.whoami then two find_tasks calls (primary + backup owner)."""
+    add_response("user.whoami", "current_user.json")
+    # primary owner tasks
+    add_response("maniphest.search", "tasks_for_current_user.json")
+    # backup owner tasks (empty)
+    add_response("maniphest.search", "tasks_where_user_is_backup_owner.json")
+
+    result = CliRunner().invoke(
+        list_tasks,
+        ["--owner", "self", "--format", "oneline"],
+        obj=client,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "T418664" in result.output
+    # user.whoami must have been called to resolve "self"
+    assert any("user.whoami" in call.request.url for call in responses.calls)
+    # find_tasks is called twice: once with owner_phid, once with backup_owner_phid
+    maniphest_search_calls = [
+        c for c in responses.calls if "maniphest.search" in c.request.url
+    ]
+    assert len(maniphest_search_calls) == 2

--- a/phable/tests/cli/test_show.py
+++ b/phable/tests/cli/test_show.py
@@ -3,7 +3,7 @@ from click.testing import CliRunner
 
 from phable.cli.show import show_task
 from phable.phabricator import PhabricatorClient
-from phable.tests.cli.conftest import load_fixture, BASE_URL
+from phable.tests.cli.conftest import add_response
 
 
 def _add_show_mocks():
@@ -12,12 +12,6 @@ def _add_show_mocks():
     add_response(endpoint="project.search", fixture="show_projects.json")
     add_response(endpoint="maniphest.search", fixture="find_subtasks.json")
     add_response(endpoint="maniphest.search", fixture="find_parent_task.json")
-
-
-def add_response(endpoint: str, fixture: str):
-    responses.add(
-        responses.POST, BASE_URL + "api/" + endpoint, json=load_fixture(fixture)
-    )
 
 
 @responses.activate

--- a/phable/tests/test_exploratory.py
+++ b/phable/tests/test_exploratory.py
@@ -104,6 +104,47 @@ def test_capture_find_parent_task_fixture(client):
 
 
 @pytest.mark.exploratory
+def test_capture_current_user_fixture(client):
+    """Capture the user.whoami HTTP response, used by tests that exercise --owner self.
+
+    Run with:
+        poetry run pytest -m exploratory -s phable/tests/exploratory_test.py::test_capture_current_user_fixture
+    """
+    captured = capture_response(client)
+    client.current_user()
+    assert captured, "No HTTP response was captured"
+    save_fixture("current_user.json", captured[0])
+
+
+@pytest.mark.exploratory
+def test_capture_find_tasks_for_current_user(client):
+    captured = capture_response(client)
+    client.find_tasks(
+        column_phids=[],
+        owner_phid="PHID-USER-oknilgmxl4rosyulvny7",
+        backup_owner_phid=None,
+        project_phid="PHID-PROJ-r456pnp5exj6uphuhwy6",
+        status=["open", "progress", "stalled"],
+    )
+    assert captured, "No HTTP response was captured"
+    save_fixture("tasks_for_current_user.json", captured[0])
+
+
+@pytest.mark.exploratory
+def test_capture_find_tasks_where_user_is_backup_owner(client):
+    captured = capture_response(client)
+    client.find_tasks(
+        column_phids=[],
+        owner_phid=None,
+        backup_owner_phid="PHID-USER-oknilgmxl4rosyulvny7",
+        project_phid="PHID-PROJ-r456pnp5exj6uphuhwy6",
+        status=["open", "progress", "stalled"],
+    )
+    assert captured, "No HTTP response was captured"
+    save_fixture("tasks_where_user_is_backup_owner.json", captured[0])
+
+
+@pytest.mark.exploratory
 def test_find_tasks_in_project_columns(client):
     current_milestone_phid = client.get_project_current_milestone_phid(
         config.phabricator_default_project_phid


### PR DESCRIPTION
Moves add_response() to conftest.py as a shared helper, adds fixtures for current_user/owner queries, and introduces test_list.py covering plain listing and --owner self resolution via user.whoami.