### PR TITLE
Add --full option to show task comments

### DIFF
--- a/phable/cli/show.py
+++ b/phable/cli/show.py
@@ -12,17 +12,22 @@ from phable.task import TASK_ID, Task
     default="plain",
     help="Output format",
 )
+@click.option("--all", "show_all", is_flag=True, help="Also show task comments")
 @click.argument("task-id", type=TASK_ID, required=True)
 @click.pass_obj
 def show_task(
-    client: PhabricatorClient, task_id: int, format: TaskFormat = TaskFormat.plain
+    client: PhabricatorClient,
+    task_id: int,
+    format: TaskFormat = TaskFormat.plain,
+    show_all: bool = False,
 ):
     """Show task details
 
     \b
     Examples:
     $ phable show T123456                 # show task details as plaintext
-    $ phable show T123456  --format=json  # show task details as json
+    $ phable show T123456 --all           # show task details with comments
+    $ phable show T123456 --format=json   # show task details as json
 
     """
     if task := client.show_task(task_id):
@@ -32,6 +37,7 @@ def show_task(
             with_tags=True,
             with_subtasks=True,
             with_parent=True,
+            with_comments=show_all,
         )
         display_task(task=task, format=format)
     else:

--- a/phable/cli/show.py
+++ b/phable/cli/show.py
@@ -12,21 +12,21 @@ from phable.task import TASK_ID, Task
     default="plain",
     help="Output format",
 )
-@click.option("--all", "show_all", is_flag=True, help="Also show task comments")
+@click.option("--full", "show_full", is_flag=True, help="Also show task comments")
 @click.argument("task-id", type=TASK_ID, required=True)
 @click.pass_obj
 def show_task(
     client: PhabricatorClient,
     task_id: int,
     format: TaskFormat = TaskFormat.plain,
-    show_all: bool = False,
+    show_full: bool = False,
 ):
     """Show task details
 
     \b
     Examples:
     $ phable show T123456                 # show task details as plaintext
-    $ phable show T123456 --all           # show task details with comments
+    $ phable show T123456 --full          # show task details with comments
     $ phable show T123456 --format=json   # show task details as json
 
     """
@@ -37,7 +37,7 @@ def show_task(
             with_tags=True,
             with_subtasks=True,
             with_parent=True,
-            with_comments=show_all,
+            with_comments=show_full,
         )
         display_task(task=task, format=format)
     else:

--- a/phable/display.py
+++ b/phable/display.py
@@ -104,6 +104,14 @@ class PlainTaskPrinter(TaskPrinter):
                 print(
                     f"{status} - {Task.from_int(subtask['id'])} - @{subtask['owner']:<10} - {subtask['fields']['name']}"
                 )
+        if "comments" in task:
+            print("Comments:")
+            if task["comments"]:
+                for i, comment in enumerate(task["comments"], start=1):
+                    print(f"--- Comment #{i} ---")
+                    print(comment)
+            else:
+                print("(none)")
 
     def print_list(self, tasks: list[dict]) -> None:
         for task in tasks:

--- a/phable/phabricator.py
+++ b/phable/phabricator.py
@@ -108,6 +108,7 @@ class PhabricatorClient:
         with_tags: bool = False,
         with_subtasks: bool = False,
         with_parent: bool = False,
+        with_comments: bool = False,
     ) -> dict[str, Any]:
         """Load additional data about a task.
 
@@ -128,6 +129,8 @@ class PhabricatorClient:
             self.enrich_task_with_subtasks(task)
         if with_parent:
             self.enrich_task_with_parent(task)
+        if with_comments:
+            self.enrich_task_with_comments(task)
         return task
 
     def enrich_task_with_author_owner(self, task: dict[str, Any]) -> None:
@@ -167,6 +170,21 @@ class PhabricatorClient:
     def enrich_task_with_parent(self, task: dict[str, Any]) -> None:
         parent = self.find_parent_task(subtask_id=task["id"])
         task["parent"] = parent
+
+    def enrich_task_with_comments(self, task: dict[str, Any]) -> None:
+        transactions = self.find_task_transactions(task_id=task["id"])
+        task["comments"] = [
+            comment["content"]["raw"]
+            for transaction in transactions
+            for comment in transaction.get("comments", [])
+            if not comment.get("removed") and comment.get("content", {}).get("raw")
+        ]
+
+    def find_task_transactions(self, task_id: int) -> list[dict[str, Any]]:
+        return self._make_request(
+            "transaction.search",
+            params={"objectIdentifier": Task.from_int(task_id)},
+        )["result"]["data"]
 
     def find_tasks(
         self,


### PR DESCRIPTION
Fetch task comments when `phable show --full` is used.

Plain output now renders a `Comments` section, JSON output includes the collected comments in the task payload.