### PR TITLE
Fix set tags transaction

### DIFF
--- a/phable/cli/set.py
+++ b/phable/cli/set.py
@@ -16,7 +16,12 @@ from phable.task import TASK_ID, TaskPriority, TaskStatus
 @click.option(
     "--status", type=click.Choice(TaskStatus._member_names_), help="Task(s) status"
 )
-@click.option("--tags", type=str, multiple=True, help="Task(s) tag(s)")
+@click.option(
+    "--tags",
+    type=str,
+    multiple=True,
+    help="Task tag(s) to add without removing existing tags",
+)
 @click.argument("task-ids", type=TASK_ID, nargs=VARIADIC)
 @click.pass_context
 @click.pass_obj
@@ -41,7 +46,7 @@ def set_task_fields(
     # Set the status for a single task
     $ phable set T123456 --status resolved
     \b
-    # Set the tags for a single task
+    # Add tags to a single task
     $ phable set T123456 --tags 'Epic' 'OKR'
 
     """
@@ -52,10 +57,12 @@ def set_task_fields(
         else:
             ctx.fail(f"Tag '{tag}' not found")
 
-    params: dict[str, str] = {}
+    params: dict[str, str | list] = {}
     if priority:
         params["priority"] = priority
     if status:
         params["status"] = status
+    if tag_phids:
+        params["projects.add"] = tag_phids
     for task_id in task_ids:
         client.create_or_edit_task(task_id=task_id, params=params)

--- a/phable/tests/cli/test_set.py
+++ b/phable/tests/cli/test_set.py
@@ -1,0 +1,47 @@
+from click.testing import CliRunner
+
+from phable.cli.set import set_task_fields
+
+
+class DummyPhabricatorClient:
+    def __init__(self):
+        self.edits = []
+        self.projects = {
+            "Data-Platform-SRE": {"phid": "PHID-PROJ-data-platform-sre"},
+            "Kafka": {"phid": "PHID-PROJ-kafka"},
+        }
+
+    def find_project_by_title(self, title):
+        return self.projects.get(title)
+
+    def create_or_edit_task(self, task_id, params):
+        self.edits.append({"task_id": task_id, "params": params})
+
+
+def test_set_task_fields_adds_tags_to_projects():
+    client = DummyPhabricatorClient()
+
+    result = CliRunner().invoke(
+        set_task_fields,
+        [
+            "T123456",
+            "--tags",
+            "Data-Platform-SRE",
+            "--tags",
+            "Kafka",
+        ],
+        obj=client,
+    )
+
+    assert result.exit_code == 0
+    assert client.edits == [
+        {
+            "task_id": 123456,
+            "params": {
+                "projects.add": [
+                    "PHID-PROJ-data-platform-sre",
+                    "PHID-PROJ-kafka",
+                ],
+            },
+        }
+    ]


### PR DESCRIPTION
The set command resolved tag names to project PHIDs but never added them to the edit params, so `phable set --tags` sent a `maniphest.edit` request with no projects transaction

Add the resolved PHIDs as a projects.add transaction, matching the non-destructive behavior used by task creation

Also clarify the `--tags` help text so callers know it appends project tags rather than replacing the existing set